### PR TITLE
docs(claude): expand the pre-PR self-review checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,9 @@
   - **Cross-cutting dimensions**: check a new feature against the dimensions this codebase already has (WSL runtime alongside native, all agent providers, all 3 UI languages), not only the one dimension the task happened to touch.
   - **Per-provider claims**: verify a provider-specific mechanism (env var, CLI flag, account model) against that provider's actual docs before implementing; do not assume symmetry with another provider's pattern.
   - **Backend/UI state parity**: if a service exposes a distinct state (e.g., a `checked`/`verified` flag for a failed vs. unknown vs. confirmed result), confirm the UI actually branches on it instead of defaulting to the "healthy" appearance.
+  - **Multi-target writes**: when a change fans out to several files or records (per-provider config files, MCP entries, etc.), validate every target before writing to any of them. A missing file and an invalid/malformed one are different cases — never silently coerce a parse failure into an empty default, since a later write could overwrite real user data with it.
+  - **Generated UI controls**: don't hand-roll a raw `<select>`, `<input type="number">`, or similar when a generated shadcn-svelte component already covers it; reuse the existing wrapper so interaction and accessibility stay consistent with the rest of the app.
+  - **Visual consistency**: check a new icon, mark, or color choice in both light and dark theme, and confirm it matches the same visual language everywhere it's reused (Provider Center, terminal headers, Usage, toolbar, etc.), not only the one surface the task happened to touch.
 
 <!-- orkestrai:begin -->
 ## Ponte Orkestrai (agentes)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,9 @@
   - **Cross-cutting dimensions**: check a new feature against the dimensions this codebase already has (WSL runtime alongside native, all agent providers, all 3 UI languages), not only the one dimension the task happened to touch.
   - **Per-provider claims**: verify a provider-specific mechanism (env var, CLI flag, account model) against that provider's actual docs before implementing; do not assume symmetry with another provider's pattern.
   - **Backend/UI state parity**: if a service exposes a distinct state (e.g., a `checked`/`verified` flag for a failed vs. unknown vs. confirmed result), confirm the UI actually branches on it instead of defaulting to the "healthy" appearance.
+  - **Multi-target writes**: when a change fans out to several files or records (per-provider config files, MCP entries, etc.), validate every target before writing to any of them. A missing file and an invalid/malformed one are different cases — never silently coerce a parse failure into an empty default, since a later write could overwrite real user data with it.
+  - **Generated UI controls**: don't hand-roll a raw `<select>`, `<input type="number">`, or similar when a generated shadcn-svelte component already covers it; reuse the existing wrapper so interaction and accessibility stay consistent with the rest of the app.
+  - **Visual consistency**: check a new icon, mark, or color choice in both light and dark theme, and confirm it matches the same visual language everywhere it's reused (Provider Center, terminal headers, Usage, toolbar, etc.), not only the one surface the task happened to touch.
 
 <!-- orkestrai:begin -->
 ## Ponte Orkestrai (agentes)


### PR DESCRIPTION
## Summary
Went through the maintainer review comments on every one of my merged PRs (#16-#30) on this repo looking for patterns not yet captured by the self-review checklist added in #26. Found three recurring classes of finding that checklist doesn't mention yet:

- **Multi-target writes** (#20): a malformed existing provider config file was silently treated as empty, so adding/removing an MCP server could have overwritten real user data. The fix distinguished "missing" from "invalid" and validated every fan-out target before writing to any of them.
- **Generated UI controls** (#30): a raw `<select>` and numeric `<input>` were introduced where the project's generated shadcn-svelte components already covered the same control.
- **Visual consistency** (#16, #18): provider marks lacked contrast in light theme and weren't used consistently across Provider Center, terminal headers, Usage, and the toolbar — checked in one theme/screen, not all of them.

## Changes
- `AGENTS.md` and `CLAUDE.md`: three new bullets under the "Verification" self-review checklist, kept in parity between both files per this project's own convention (established by #26, which specifically called out keeping this guidance synced).

## Verification
- [x] Docs-only change, no runtime code touched
- [x] Both files updated identically (parity)

## Checklist
- [x] Commit messages are in English and follow Conventional Commits
- [x] New UI strings exist in pt-BR, English, and Spanish — not applicable, no UI copy
- [x] User-visible changes update all required changelogs and documentation — not applicable, this only affects contributor/agent guidance, not app behavior
- [x] New features include a use case and onboarding tour in all three languages — not applicable
- [x] No secrets, databases, workspace data, models, or build artifacts are included
- [x] Visual changes include screenshots or a short recording — not applicable