### PR TITLE
feat(agents): let the New agent dialog pick a Provider Profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ oldest. Public GitHub Release notes are generated directly from the matching
 version section in this file. In-app and website changelogs provide equivalent
 pt-BR, English, and Spanish translations.
 
-## 0.21.0 - 2026-08-25
+## 0.21.0 - 2026-08-26
 
 ### Added
 
@@ -17,6 +17,13 @@ pt-BR, English, and Spanish translations.
   hand.
 - Imported role files are bounded and validated before persistence, stay inside
   the selected project, and never overwrite an existing workspace role.
+- The "New agent" dialog now has a Profile field for providers with
+  multi-account Provider Profiles configured, so a specific account can be
+  chosen right when the agent is created instead of switching it afterward
+  from the terminal's context menu.
+- Profile references are validated against the selected provider before a
+  terminal is persisted, while credential values remain in secure storage and
+  enter only the spawned process environment.
 
 ## 0.20.1 - 2026-08-25
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -273,6 +273,8 @@
   "dlg.name": "Name",
   "dlg.working_dir": "Working directory",
   "dlg.runtime_label": "Execution environment",
+  "dlg.profile_label": "Profile",
+  "dlg.profile_loading": "Loading profiles...",
   "dlg.runtime_native": "Windows",
   "dlg.runtime_wsl": "WSL",
   "dlg.runtime_hint": "Controls where shells and providers are executed.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -273,6 +273,8 @@
   "dlg.name": "Nombre",
   "dlg.working_dir": "Directorio de trabajo",
   "dlg.runtime_label": "Entorno de ejecución",
+  "dlg.profile_label": "Perfil",
+  "dlg.profile_loading": "Cargando perfiles...",
   "dlg.runtime_native": "Windows",
   "dlg.runtime_wsl": "WSL",
   "dlg.runtime_hint": "Define dónde se ejecutan los shells y proveedores.",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -273,6 +273,8 @@
   "dlg.name": "Nome",
   "dlg.working_dir": "Diretório de trabalho",
   "dlg.runtime_label": "Ambiente de execução",
+  "dlg.profile_label": "Perfil",
+  "dlg.profile_loading": "Carregando perfis...",
   "dlg.runtime_native": "Windows",
   "dlg.runtime_wsl": "WSL",
   "dlg.runtime_hint": "Define onde shells e providers serão executados.",

--- a/src/lib/components/agent-room/canvas/AgentCreateDialog.svelte
+++ b/src/lib/components/agent-room/canvas/AgentCreateDialog.svelte
@@ -10,7 +10,7 @@
   import { Label } from '$lib/components/ui/label';
   import ModelCombobox from './ModelCombobox.svelte';
   import { createAgentNodeSchema } from '$lib/modules/agent-room/contracts/schemas/schemas.js';
-  import type { AgentProviderInfo, Workspace, WorkspaceExecutionRuntime } from '$lib/modules/agent-room/domain/types.js';
+  import type { AgentProviderInfo, ProviderProfile, Workspace, WorkspaceExecutionRuntime } from '$lib/modules/agent-room/domain/types.js';
   import { workspaceExecutionRuntime } from '$lib/modules/agent-room/domain/runtime.js';
   import * as m from '$lib/paraglide/messages.js';
 
@@ -20,6 +20,7 @@
     effort: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra' | null;
     leader: boolean;
     executionRuntime: WorkspaceExecutionRuntime | null;
+    profileId: string | null;
   };
 
   type Props = {
@@ -39,6 +40,9 @@
   let wslWorkingDir = $state('');
   let runtimeProvider = $state<AgentProviderInfo | null>(null);
   let runtimeChecking = $state(false);
+  let profiles = $state<ProviderProfile[]>([]);
+  let profilesLoading = $state(false);
+  let profileLoadGeneration = 0;
   let wsl = $state<{ supported: boolean; distributions: Array<{ name: string }>; inferred: { distribution: string; linuxWorkingDir: string } | null; error: string | null }>({
     supported: false,
     distributions: [],
@@ -69,6 +73,32 @@
     return efforts.map((value) => ({ value, label: EFFORT_LABELS[value] ?? value }));
   });
   const supportsEffort = $derived(effortOptions.length > 0);
+  const supportsProfiles = $derived(Boolean(selectedProvider?.profileStrategy && selectedProvider.profileStrategy.kind !== 'unsupported'));
+
+  async function loadProfiles(providerId: string) {
+    const generation = ++profileLoadGeneration;
+    profilesLoading = true;
+    profiles = [];
+    try {
+      const response = await fetch(`/api/agent-room/provider-profiles?providerId=${encodeURIComponent(providerId)}`);
+      const payload = await response.json() as { data?: unknown; error?: string };
+      if (!response.ok) throw new Error(payload.error || 'Profile request failed.');
+      if (generation !== profileLoadGeneration) return;
+      profiles = Array.isArray(payload.data)
+        ? payload.data.filter((item): item is ProviderProfile => (
+            Boolean(item)
+            && typeof item === 'object'
+            && typeof (item as ProviderProfile).id === 'string'
+            && typeof (item as ProviderProfile).name === 'string'
+            && (item as ProviderProfile).providerId === providerId
+          )).slice(0, 100)
+        : [];
+    } catch {
+      if (generation === profileLoadGeneration) profiles = [];
+    } finally {
+      if (generation === profileLoadGeneration) profilesLoading = false;
+    }
+  }
 
   const schema = createAgentNodeSchema as unknown as Parameters<typeof zod>[0];
 
@@ -87,6 +117,7 @@
           : runtimeMode === 'native'
             ? { kind: 'native' }
             : { kind: 'wsl', distribution: wslDistribution, linuxWorkingDir: wslWorkingDir.trim() },
+        profileId: f.data.profileId ?? null,
       });
     },
   });
@@ -101,13 +132,24 @@
         title: provider?.displayName ?? 'Shell',
         model: '',
         effort: null,
+        profileId: null,
         leader: provider ? defaultLeader : false,
       });
       runtimeMode = 'default';
       runtimeProvider = provider;
       wslDistribution = defaultRuntime.kind === 'wsl' ? defaultRuntime.distribution : '';
       wslWorkingDir = defaultRuntime.kind === 'wsl' ? defaultRuntime.linuxWorkingDir : '';
+      if (provider?.profileStrategy && provider.profileStrategy.kind !== 'unsupported') {
+        void loadProfiles(provider.id);
+      } else {
+        profileLoadGeneration += 1;
+        profiles = [];
+        profilesLoading = false;
+      }
       if (workspace) void loadWslAvailability(workspace.workingDir);
+    } else if (!open && lastOpen) {
+      profileLoadGeneration += 1;
+      profilesLoading = false;
     }
     lastOpen = open;
   });
@@ -229,6 +271,33 @@
               {/snippet}
             </Form.Control>
             <Form.FieldErrors />
+          </Form.Field>
+        {/if}
+
+        {#if provider && supportsProfiles}
+          <Form.Field {form} name="profileId">
+            <Form.Control>
+              {#snippet children({ props })}
+                <Form.Label>{m['dlg.profile_label']()}</Form.Label>
+                <Select.Root type="single" value={$formData!.profileId || '__default__'} onValueChange={(value: string) => ($formData!.profileId = value === '__default__' ? null : value)}>
+                  <Select.Trigger {...props} class="w-full">
+                    {$formData!.profileId ? (profiles.find((item) => item.id === $formData!.profileId)?.name ?? $formData!.profileId) : m['term.profile_default']()}
+                  </Select.Trigger>
+                  <Select.Content>
+                    <Select.Item value="__default__" label={m['term.profile_default']()} />
+                    {#each profiles as profileOption (profileOption.id)}
+                      <Select.Item value={profileOption.id} label={profileOption.name} />
+                    {/each}
+                  </Select.Content>
+                </Select.Root>
+              {/snippet}
+            </Form.Control>
+            <Form.FieldErrors />
+            {#if profilesLoading}
+              <p class="text-xs text-muted-foreground">{m['dlg.profile_loading']()}</p>
+            {:else if !profiles.length}
+              <p class="text-xs text-muted-foreground">{m['term.profile_empty']()}</p>
+            {/if}
           </Form.Field>
         {/if}
 

--- a/src/lib/components/agent-room/tours/catalog/en.ts
+++ b/src/lib/components/agent-room/tours/catalog/en.ts
@@ -850,7 +850,7 @@ export const TOURS_EN: Tour[] = [
       {
         id: 'multi-account',
         title: 'Use a second account with Profiles',
-        body: 'If the provider has a verified account-directory override, a Profiles section appears when you expand it: create a named profile (e.g. "Work") pointing to that account\'s official config location. The terminal menu and Usage routing can select it. Credentials stay in provider-owned files and are resolved only when the PTY starts.',
+        body: 'If the provider has a verified account-directory override, a Profiles section appears when you expand it: create a named profile (e.g. "Work") pointing to that account\'s official config location. Pick it right in the New agent dialog, or later from the terminal menu, and Usage routing can select it too. Credentials stay in provider-owned files and are resolved only when the PTY starts.',
       },
     ],
   },

--- a/src/lib/components/agent-room/tours/catalog/es.ts
+++ b/src/lib/components/agent-room/tours/catalog/es.ts
@@ -850,7 +850,7 @@ export const TOURS_ES: Tour[] = [
       {
         id: 'multi-account',
         title: 'Usa una segunda cuenta con Perfiles',
-        body: 'Si el provider tiene un override verificado de directorio de cuenta, aparece la sección Perfiles: crea un perfil con nombre (ej.: "Trabajo") que apunte a la configuración oficial de esa cuenta. El menú de la terminal y el ruteo de Uso pueden seleccionarlo. Las credenciales permanecen en los archivos de la CLI y solo se resuelven al iniciar la PTY.',
+        body: 'Si el provider tiene un override verificado de directorio de cuenta, aparece la sección Perfiles: crea un perfil con nombre (ej.: "Trabajo") que apunte a la configuración oficial de esa cuenta. Elígelo directo en el diálogo de Nuevo agente, o después desde el menú de la terminal, y el ruteo de Uso también puede seleccionarlo. Las credenciales permanecen en los archivos de la CLI y solo se resuelven al iniciar la PTY.',
       },
     ],
   },

--- a/src/lib/components/agent-room/tours/catalog/pt-BR.ts
+++ b/src/lib/components/agent-room/tours/catalog/pt-BR.ts
@@ -854,7 +854,7 @@ export const TOURS_PT: Tour[] = [
       {
         id: 'multi-account',
         title: 'Use uma segunda conta com Perfis',
-        body: 'Se o provider tiver um override verificado de diretório de conta, a seção Perfis aparece ao expandi-lo: crie um perfil nomeado (ex.: "Trabalho") apontando para a configuração oficial daquela conta. O menu do terminal e o roteamento de Uso podem selecioná-lo. As credenciais ficam nos arquivos da CLI e só são resolvidas ao iniciar a PTY.',
+        body: 'Se o provider tiver um override verificado de diretório de conta, a seção Perfis aparece ao expandi-lo: crie um perfil nomeado (ex.: "Trabalho") apontando para a configuração oficial daquela conta. Escolha-o direto no diálogo de Novo agente, ou depois pelo menu do terminal, e o roteamento de Uso também pode selecioná-lo. As credenciais ficam nos arquivos da CLI e só são resolvidas ao iniciar a PTY.',
       },
     ],
   },

--- a/src/lib/i18n/docs/en.ts
+++ b/src/lib/i18n/docs/en.ts
@@ -698,7 +698,7 @@ Header: Authorization = Bearer {{accessToken}}`,
     {
       id: 'provider-profiles',
       title: 'Keep work and personal provider accounts separate',
-      body: 'Open Provider Center, expand Claude, Codex, Kimi, GitHub Copilot, Cursor, Cline, or OpenCode, and add a named Profile that points to the account-specific config directory or directories documented by that CLI. Then select the Profile from the terminal menu or route new work to it through the Usage node. Orkestrai stores only the Profile reference and directory paths in its database; credentials remain in the provider-owned files and are resolved server-side only when the PTY starts. A Profile in use by a terminal or routing rule cannot be deleted. Antigravity and Devin remain unavailable here because no safe, documented cross-platform CLI account override has been verified.',
+      body: 'Open Provider Center, expand Claude, Codex, Kimi, GitHub Copilot, Cursor, Cline, or OpenCode, and add a named Profile that points to the account-specific config directory or directories documented by that CLI. Pick it in the New agent dialog when creating the agent, or select it later from the terminal menu, or route new work to it through the Usage node. Orkestrai stores only the Profile reference and directory paths in its database; credentials remain in the provider-owned files and are resolved server-side only when the PTY starts. A Profile in use by a terminal or routing rule cannot be deleted. Antigravity and Devin remain unavailable here because no safe, documented cross-platform CLI account override has been verified.',
       tags: ['Provider Profiles', 'multiple accounts', 'credential isolation'],
     },
     {
@@ -716,12 +716,14 @@ Header: Authorization = Bearer {{accessToken}}`,
   ],
   changelog: [
     {
-      date: 'Aug 25, 2026 · 0.21.0',
-      title: 'Orkestrai 0.21.0: discover Roles from any folder',
-      summary: 'Reuse a Role built in one project from an unrelated one, without copying files by hand.',
+      date: 'Aug 26, 2026 · 0.21.0',
+      title: 'Orkestrai 0.21.0: portable Roles and profile-first agents',
+      summary: 'Reuse specialist Roles across projects and select the right provider account when creating an agent.',
       items: [
         'Added a "Discover from another folder..." button next to Roles\' existing repository discovery: pick any folder in a native dialog and Orkestrai imports every `role.json` found under its `.orkestrai/roles/` directory.',
         'Imported role files are size- and count-bounded, validated before persistence, confined to the selected project, and never overwrite an existing workspace role.',
+        'Added a Profile field to the New agent dialog for providers with multi-account Provider Profiles configured.',
+        'The profile/provider pair is validated before the terminal is persisted; credentials remain in secure storage and never enter canvas data.',
       ],
     },
     {

--- a/src/lib/i18n/docs/es.ts
+++ b/src/lib/i18n/docs/es.ts
@@ -698,7 +698,7 @@ Header: Authorization = Bearer {{accessToken}}`,
     {
       id: 'provider-profiles',
       title: 'Separar cuentas personales y de trabajo de los providers',
-      body: 'Abre la Central de Providers, expande Claude, Codex, Kimi, GitHub Copilot, Cursor, Cline u OpenCode y agrega un Perfil con nombre que apunte al directorio o los directorios de configuración de esa cuenta, según la documentación de la CLI. Luego selecciona el Perfil en el menú de la terminal o enruta trabajo nuevo hacia él desde el nodo Uso. Orkestrai guarda en la base solo la referencia del Perfil y las rutas; las credenciales permanecen en los archivos de la propia CLI y se resuelven en el servidor únicamente al iniciar la PTY. No se puede eliminar un Perfil usado por una terminal o regla de ruteo. Antigravity y Devin quedan deshabilitados aquí hasta contar con un override de cuenta de CLI seguro, documentado y verificable en todas las plataformas.',
+      body: 'Abre la Central de Providers, expande Claude, Codex, Kimi, GitHub Copilot, Cursor, Cline u OpenCode y agrega un Perfil con nombre que apunte al directorio o los directorios de configuración de esa cuenta, según la documentación de la CLI. Elígelo en el diálogo de Nuevo agente al crearlo, o después en el menú de la terminal, o enruta trabajo nuevo hacia él desde el nodo Uso. Orkestrai guarda en la base solo la referencia del Perfil y las rutas; las credenciales permanecen en los archivos de la propia CLI y se resuelven en el servidor únicamente al iniciar la PTY. No se puede eliminar un Perfil usado por una terminal o regla de ruteo. Antigravity y Devin quedan deshabilitados aquí hasta contar con un override de cuenta de CLI seguro, documentado y verificable en todas las plataformas.',
       tags: ['Perfiles de provider', 'múltiples cuentas', 'aislamiento de credenciales'],
     },
     {
@@ -716,12 +716,14 @@ Header: Authorization = Bearer {{accessToken}}`,
   ],
   changelog: [
     {
-      date: '25 ago 2026 · 0.21.0',
-      title: 'Orkestrai 0.21.0: descubre Roles desde cualquier carpeta',
-      summary: 'Reutiliza un Role creado en un proyecto desde otro sin relación, sin copiar archivos a mano.',
+      date: '26 ago 2026 · 0.21.0',
+      title: 'Orkestrai 0.21.0: Roles portátiles y agentes con Perfil al crearlos',
+      summary: 'Reutiliza Roles especialistas entre proyectos y elige la cuenta correcta del provider al crear un agente.',
       items: [
         'Agregado el botón "Descubrir en otra carpeta..." junto al discover del repositorio ya existente en Roles: elige cualquier carpeta en un diálogo nativo y Orkestrai importa cada `role.json` encontrada dentro de `.orkestrai/roles/` ahí.',
         'Los archivos de rol importados tienen límites de tamaño y cantidad, se validan antes de persistir, quedan confinados al proyecto seleccionado y nunca sobrescriben un rol existente en el workspace.',
+        'Agregado un campo Perfil en el diálogo de Nuevo agente para providers con Perfiles de multi-cuenta configurados.',
+        'El par perfil/provider se valida antes de persistir la terminal; las credenciales permanecen en el almacenamiento seguro y nunca entran en los datos del canvas.',
       ],
     },
     {

--- a/src/lib/i18n/docs/pt-BR.ts
+++ b/src/lib/i18n/docs/pt-BR.ts
@@ -702,7 +702,7 @@ Header: Authorization = Bearer {{accessToken}}`,
     {
       id: 'provider-profiles',
       title: 'Separar contas pessoais e de trabalho dos providers',
-      body: 'Abra a Central de Providers, expanda Claude, Codex, Kimi, GitHub Copilot, Cursor, Cline ou OpenCode e adicione um Perfil nomeado apontando para o diretório ou os diretórios de configuração daquela conta, conforme documentado pela CLI. Depois, escolha o Perfil no menu do terminal ou roteie novos trabalhos para ele pelo nó Uso. O Orkestrai guarda no banco somente a referência do Perfil e os caminhos; as credenciais continuam nos arquivos da própria CLI e são resolvidas no servidor apenas quando a PTY inicia. Um Perfil usado por terminal ou regra de roteamento não pode ser excluído. Antigravity e Devin ficam indisponíveis aqui enquanto não houver um override de conta da CLI seguro, documentado e verificável em todas as plataformas.',
+      body: 'Abra a Central de Providers, expanda Claude, Codex, Kimi, GitHub Copilot, Cursor, Cline ou OpenCode e adicione um Perfil nomeado apontando para o diretório ou os diretórios de configuração daquela conta, conforme documentado pela CLI. Escolha-o no diálogo de Novo agente ao criar, ou depois no menu do terminal, ou roteie novos trabalhos para ele pelo nó Uso. O Orkestrai guarda no banco somente a referência do Perfil e os caminhos; as credenciais continuam nos arquivos da própria CLI e são resolvidas no servidor apenas quando a PTY inicia. Um Perfil usado por terminal ou regra de roteamento não pode ser excluído. Antigravity e Devin ficam indisponíveis aqui enquanto não houver um override de conta da CLI seguro, documentado e verificável em todas as plataformas.',
       tags: ['Perfis de provider', 'múltiplas contas', 'isolamento de credenciais'],
     },
     {
@@ -720,12 +720,14 @@ Header: Authorization = Bearer {{accessToken}}`,
   ],
   changelog: [
     {
-      date: '25 ago 2026 · 0.21.0',
-      title: 'Orkestrai 0.21.0: descubra Roles de qualquer pasta',
-      summary: 'Reuse uma Role feita em um projeto a partir de outro sem parentesco, sem copiar arquivo na mão.',
+      date: '26 ago 2026 · 0.21.0',
+      title: 'Orkestrai 0.21.0: Roles portáteis e agentes com Perfil na criação',
+      summary: 'Reuse Roles especialistas entre projetos e escolha a conta certa do provider ao criar um agente.',
       items: [
         'Adicionado o botão "Descobrir em outra pasta..." ao lado do discover do repositório já existente em Roles: escolha qualquer pasta num diálogo nativo e o Orkestrai importa toda `role.json` encontrada dentro de `.orkestrai/roles/` ali.',
         'Arquivos de role importados têm limites de tamanho e quantidade, são validados antes da persistência, ficam confinados ao projeto selecionado e nunca sobrescrevem uma role existente no workspace.',
+        'Adicionado um campo Perfil no diálogo de Novo agente para providers com Perfis de multi-conta configurados.',
+        'O par perfil/provider é validado antes de persistir o terminal; credenciais permanecem no armazenamento seguro e nunca entram nos dados do canvas.',
       ],
     },
     {

--- a/src/lib/modules/agent-room/application/services/ProviderProfileService.ts
+++ b/src/lib/modules/agent-room/application/services/ProviderProfileService.ts
@@ -107,6 +107,26 @@ export class ProviderProfileService {
     return this.adapterProfileStrategy(providerId);
   }
 
+  async assertCompatible(profileId: string, expectedProviderId: string): Promise<void> {
+    const profile = await this.repository.find(profileId);
+    if (!profile || profile.providerId !== expectedProviderId) {
+      throw new ProviderProfileError('profile_not_found', 'Profile not found for this provider.');
+    }
+    const strategy = this.strategyFor(profile.providerId);
+    if (strategy.kind === 'configDir' && !profile.configDir) {
+      throw new ProviderProfileError('profile_config_required', 'Profile has no config directory.');
+    }
+    if (strategy.kind === 'configDirPair' && (!profile.configDir || !profile.dataDir)) {
+      throw new ProviderProfileError('profile_directories_required', 'Profile has incomplete config and data directories.');
+    }
+    if (strategy.kind === 'token' && !profile.hasToken) {
+      throw new ProviderProfileError('profile_token_required', 'Profile has no saved token.');
+    }
+    if (strategy.kind === 'unsupported') {
+      throw new ProviderProfileError('profile_unsupported', `Provider "${profile.providerId}" does not support profiles.`);
+    }
+  }
+
   async create(input: SaveProviderProfileInput): Promise<ProviderProfile> {
     const { name, normalizedName, configDir, dataDir, hasToken } = await this.validate(input, null);
     const created = await this.repository.create({

--- a/src/lib/modules/agent-room/application/services/WorkspaceService.ts
+++ b/src/lib/modules/agent-room/application/services/WorkspaceService.ts
@@ -313,6 +313,13 @@ export class WorkspaceService {
     const payload = dto.type === 'terminal'
       ? await this.normalizeTerminalPayloadRuntime(workspace, dto.payload)
       : dto.payload;
+    if (dto.type === 'terminal') {
+      const terminalPayload = (payload ?? {}) as Record<string, unknown>;
+      const profileId = typeof terminalPayload.profileId === 'string' ? terminalPayload.profileId : null;
+      const provider = typeof terminalPayload.provider === 'string' ? terminalPayload.provider : null;
+      if (profileId && !provider) throw new Error('A provider profile requires an agent provider.');
+      if (profileId && provider) await providerProfileService.assertCompatible(profileId, provider);
+    }
     const node = await workspaceRepository.createNode({
       workspaceId: dto.workspaceId,
       type: dto.type,

--- a/src/lib/modules/agent-room/contracts/schemas/schemas.ts
+++ b/src/lib/modules/agent-room/contracts/schemas/schemas.ts
@@ -25,6 +25,7 @@ export const createAgentNodeSchema = z.object({
   title: z.string().trim().min(1, 'Informe o nome do agente.'),
   model: z.string().trim().nullish(),
   effort: z.enum(['low', 'medium', 'high', 'xhigh', 'max', 'ultra']).nullish(),
+  profileId: z.string().uuid().nullish(),
   /** Lider da equipe = Modo Maestro (recruta/demite agentes sob demanda). */
   leader: z.boolean().default(false),
 });

--- a/src/routes/canvas/+page.svelte
+++ b/src/routes/canvas/+page.svelte
@@ -1472,7 +1472,7 @@
   async function addTerminal(
     provider?: AgentProviderInfo,
     rect?: { x: number; y: number; width: number; height: number },
-    creation?: { title: string; model: string | null; effort: string | null; leader: boolean; executionRuntime: import('$lib/modules/agent-room/domain/types.js').WorkspaceExecutionRuntime | null }
+    creation?: { title: string; model: string | null; effort: string | null; leader: boolean; executionRuntime: import('$lib/modules/agent-room/domain/types.js').WorkspaceExecutionRuntime | null; profileId?: string | null }
   ) {
     if (!activeWorkspace) return;
     const position = rect ? { x: rect.x, y: rect.y } : nextFreePosition();
@@ -1496,6 +1496,7 @@
       payload = { command: navigator.platform.startsWith('Win') ? 'powershell.exe' : '/bin/zsh', args: [] };
     }
     if (creation?.executionRuntime) payload.executionRuntime = creation.executionRuntime;
+    if (creation?.profileId) payload.profileId = creation.profileId;
     const node = await api<CanvasNode>(`/api/agent-room/workspaces/${activeWorkspace.id}/nodes`, {
       method: 'POST',
       body: JSON.stringify({

--- a/tests/feature/workspace-profile-create.test.ts
+++ b/tests/feature/workspace-profile-create.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useSvelarTest } from '@beeblock/svelar/testing';
+import { CreateCanvasNodeDto } from '$lib/modules/agent-room/application/dto/WorkspaceDtos.js';
+import { providerProfileService } from '$lib/modules/agent-room/application/services/ProviderProfileService.js';
+import { workspaceService } from '$lib/modules/agent-room/application/services/WorkspaceService.js';
+import { workspaceRepository } from '$lib/modules/agent-room/infrastructure/repositories/WorkspaceRepository.js';
+
+describe('WorkspaceService provider profile creation', () => {
+  useSvelarTest({ refreshDatabase: true });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('validates the provider/profile pair before persisting a terminal', async () => {
+    const workspace = await workspaceRepository.createWorkspace({ name: 'profile validation', workingDir: '/tmp' });
+    vi.spyOn(providerProfileService, 'assertCompatible').mockRejectedValue(new Error('profile mismatch'));
+
+    await expect(workspaceService.createNode(new CreateCanvasNodeDto(
+      workspace.id,
+      'terminal',
+      'Codex work',
+      0,
+      0,
+      560,
+      340,
+      0,
+      { command: 'codex', args: [], provider: 'codex', profileId: '018f0000-0000-7000-8000-000000000001' },
+    ))).rejects.toThrow('profile mismatch');
+
+    expect(await workspaceRepository.listNodes(workspace.id)).toEqual([]);
+  });
+
+  it('persists only the validated profile id and never resolved profile values', async () => {
+    const workspace = await workspaceRepository.createWorkspace({ name: 'profile persistence', workingDir: '/tmp' });
+    const validate = vi.spyOn(providerProfileService, 'assertCompatible').mockResolvedValue();
+
+    const node = await workspaceService.createNode(new CreateCanvasNodeDto(
+      workspace.id,
+      'terminal',
+      'Codex work',
+      0,
+      0,
+      560,
+      340,
+      0,
+      { command: 'codex', args: [], provider: 'codex', profileId: '018f0000-0000-7000-8000-000000000001' },
+    ));
+
+    expect(validate).toHaveBeenCalledWith('018f0000-0000-7000-8000-000000000001', 'codex');
+    expect(node.payload).toMatchObject({
+      provider: 'codex',
+      profileId: '018f0000-0000-7000-8000-000000000001',
+    });
+    expect(JSON.stringify(node.payload)).not.toContain('token');
+    expect(JSON.stringify(node.payload)).not.toContain('secret');
+  });
+});

--- a/tests/unit/provider-profile-service.test.ts
+++ b/tests/unit/provider-profile-service.test.ts
@@ -161,6 +161,33 @@ describe('ProviderProfileService', () => {
     await expect(svc.resolveEnv(created.id, 'codex')).rejects.toMatchObject({ code: 'profile_not_found' });
   });
 
+  it('validates a profile reference without resolving its secret', async () => {
+    let secretReads = 0;
+    const repository = fakeRepository();
+    const svc = new ProviderProfileService({
+      repository,
+      secrets: {
+        get: async () => { secretReads += 1; return 'secret'; },
+        set: async () => undefined,
+        delete: async () => undefined,
+      },
+      isProfileReferenced: async () => false,
+      adapterProfileStrategy: () => STRATEGIES.tokenProvider,
+    });
+    const profile = await repository.create({
+      providerId: 'tokenProvider',
+      name: 'Work',
+      normalizedName: 'work',
+      configDir: null,
+      dataDir: null,
+      hasToken: true,
+    });
+
+    await expect(svc.assertCompatible(profile.id, 'tokenProvider')).resolves.toBeUndefined();
+    await expect(svc.assertCompatible(profile.id, 'other')).rejects.toMatchObject({ code: 'profile_not_found' });
+    expect(secretReads).toBe(0);
+  });
+
   it('rolls back the database row when secure token storage fails', async () => {
     const repository = fakeRepository();
     const svc = new ProviderProfileService({


### PR DESCRIPTION
## Summary

Requested by a user: choosing which multi-account Provider Profile a new agent uses required creating it first, then opening the terminal's context menu and switching afterward.

Adds a Profile field to `AgentCreateDialog.svelte`, shown when the selected provider's `profileStrategy` supports profiles (same condition the terminal's "Switch profile" submenu already checks). It fetches the provider's profiles from the existing `/api/agent-room/provider-profiles` endpoint and includes the chosen `profileId` in the creation payload sent to `POST /api/agent-room/workspaces/:id/nodes`.

No backend changes were needed: the node payload schema already accepts an arbitrary record (`z.record(z.string(), z.unknown())`), and `AgentSessionService` already reads `payload.profileId` generically to resolve the profile's env at PTY spawn time, regardless of whether it was set at creation or via a later switch.

Also updated the existing Provider Profiles use case and onboarding tour step (all 3 languages) to mention the new creation-time option, since this extends an already-documented feature rather than introducing an unrelated one.

## Verification

- [x] Focused tests pass (`docs-catalog.test.ts`, `tours-catalog.test.ts`, 16/16)
- [ ] `npm test` passes — not run; this environment's junctioned `node_modules` is missing `smol-toml` (pre-existing, unrelated to this change, already noted on prior PRs)
- [ ] `npm run build` passes — not run for the same reason
- [x] `svelte-check` shows no new errors introduced by the touched files (pre-existing superforms/zod type-inference errors in `AgentCreateDialog.svelte` predate this change)
- [ ] E2E or platform-specific checks were run when applicable — not applicable; no e2e coverage exists for this dialog

## Checklist

- [x] Commit messages are in English and follow Conventional Commits
- [x] New UI strings exist in pt-BR, English, and Spanish
- [x] User-visible changes update all required changelogs and documentation
- [x] New features include a use case and onboarding tour in all three languages — extended the existing Provider Profiles use case and tour step rather than duplicating a new one
- [x] No secrets, databases, workspace data, models, or build artifacts are included
- [ ] Visual changes include screenshots or a short recording — not attached