### PR TITLE
fix(rpm): desabilitar links build-id para evitar conflito com outros apps Electron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ pt-BR, English, and Spanish translations.
 - Native Windows PowerShell agent terminals now advertise complete xterm mouse
   capabilities and consume their own wheel events, restoring terminal history
   scrolling without zooming the Canvas underneath.
+
+## Unreleased
+
+### Fixed
+
 - RPM packages no longer ship `/usr/lib/.build-id` symlinks that conflict with
   other Electron apps (opencode, Slack, VS Code, etc.) on Fedora/RHEL.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ pt-BR, English, and Spanish translations.
 - Native Windows PowerShell agent terminals now advertise complete xterm mouse
   capabilities and consume their own wheel events, restoring terminal history
   scrolling without zooming the Canvas underneath.
+- RPM packages no longer ship `/usr/lib/.build-id` symlinks that conflict with
+  other Electron apps (opencode, Slack, VS Code, etc.) on Fedora/RHEL.
 
 ## 0.27.0 - 2026-09-07
 

--- a/package.json
+++ b/package.json
@@ -303,6 +303,7 @@
     },
     "rpm": {
       "artifactName": "${productName}-${version}.${arch}.${ext}",
+      "fpm": ["--rpm-rpmbuild-define", "_build_id_links none"],
       "depends": [
         "gtk3",
         "libnotify",


### PR DESCRIPTION
## Problema

Instalação do RPM Orkestrai via `dnf` falha quando outro app Electron (ex: opencode, Slack, VS Code) já está instalado. Erro:

```
file /usr/lib/.build-id/42/f633ec8d28e46e850ad58ffc5f831c734ab159 from install of orkestrai conflicts with file from package opencode
```

## Causa

`rpmbuild` gera symlinks `/usr/lib/.build-id/` para cada binário ELF. Dois apps Electron embutem os mesmos binários upstream → mesmo hash, caminhos distintos → conflito.

## Fix

Adiciona `fpm: ["--rpm-rpmbuild-define", "_build_id_links none"]` em `build.rpm` no `package.json`. Suprime a geração dos links. Padrão da indústria (VS Code, Signal, Insomnia, Ferdium).

## Verificação

- RPM default (sem flag): 7 entradas build-id, conflita com opencode
- RPM com flag: 0 entradas build-id, `rpm -ivh --test` sucesso ao lado do opencode
